### PR TITLE
Update fast-feed to version 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedrapp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A service for parsing RSS and Atom feeds.",
   "main": "dist/index.js",
   "scripts": {
@@ -46,7 +46,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.0",
     "express": "~4.14.1",
-    "fast-feed": "^1.5.5",
+    "fast-feed": "^1.6.0",
     "jade": "~1.11.0",
     "less-middleware": "~2.2.0",
     "lodash": "^4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,11 +1005,11 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fast-feed@^1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/fast-feed/-/fast-feed-1.5.5.tgz#937d26e0f724eb75acba67af28ad6fbe690f1c77"
+fast-feed@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fast-feed/-/fast-feed-1.6.0.tgz#ed2963d5c91d59f2af80291a6c614abd18c4d01c"
   dependencies:
-    nan "~2.3.5"
+    nan "^2.10.0"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1599,6 +1599,7 @@ jade@~1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
+    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 
@@ -1960,9 +1961,9 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@~2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.5.tgz#822a0dc266290ce4cd3a12282ca3e7e364668a08"
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2887,6 +2888,15 @@ type-is@~1.6.14:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+uglify-js@^2.4.19:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.21"


### PR DESCRIPTION
This adds enclosure support in RSS 2.

Fixes #64 and likely #78.