### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keymetrics/pm2:8-alpine
+FROM keymetrics/pm2:16-alpine
 
 # Bundle APP files
 COPY bin bin/
@@ -12,7 +12,7 @@ COPY yarn.lock .
 COPY ecosystem.config.js .
 
 # Add Python for node-gyp / fastfeed
-RUN apk add --update python python-dev py-pip build-base
+RUN apk add --update python3 python3-dev py-pip build-base
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY bin bin/
 COPY public public/
 COPY routes routes/
 COPY src src/
+COPY models models/
 COPY views views/
 COPY package.json .
 COPY yarn.lock .


### PR DESCRIPTION
The current Dockerfile fails to build due to some certificate expiration error. 

```
error /node_modules/fast-feed: Command failed.
Exit code: 1
Command: node-gyp rebuild
Arguments:
Directory: /node_modules/fast-feed
Output:
gyp WARN install got an error, rolling back install
gyp ERR! configure error
gyp ERR! stack Error: certificate has expired
gyp ERR! stack     at TLSSocket.<anonymous> (_tls_wrap.js:1116:38)
gyp ERR! stack     at emitNone (events.js:106:13)
gyp ERR! stack     at TLSSocket.emit (events.js:208:7)
gyp ERR! stack     at TLSSocket._finishInit (_tls_wrap.js:643:8)
gyp ERR! stack     at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:473:38)
gyp ERR! System Linux 5.4.0-89-generic
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /node_modules/fast-feed
gyp ERR! node -v v8.17.0
gyp ERR! node-gyp -v v5.0.5
gyp ERR! not ok
```

I haven't dug that deep, but I assume it's an expired root/intermediate certificate, somewhere in that old version of Alpine.

The `models/` folder was also missing in the Dockerfile, causing complaints about being unable to load the Redis client.